### PR TITLE
fix for broken build

### DIFF
--- a/examples/usb/usbfatfs/source/main.c
+++ b/examples/usb/usbfatfs/source/main.c
@@ -26,6 +26,7 @@ int _main(void)
 	initKernel();
 	initLibc();
 	initNetwork();
+	initUsb();
 
 	struct sockaddr_in server;
 


### PR DESCRIPTION
usbfatfs example does not build: undefined reference to 'sceUsbd*'
missing reference to deal with usb (the entire initialization): just call it fixes building, since linker can find references
