### PR TITLE
Fix sysctl* signatures

### DIFF
--- a/libPS4/include/kernel.h
+++ b/libPS4/include/kernel.h
@@ -18,8 +18,8 @@ extern int (*sceKernelGettimeofday)(SceKernelTimeval *tp);
 extern uint64_t (*sceKernelGetProcessTime)(void);
 extern int (*sceKernelGetCurrentCpu)(void);
 
-extern int (*sysctl)(int *name, unsigned int namelen, char *oldval, size_t *oldlen, char *newval, size_t *newlen);
-extern int (*sysctlbyname)(char *name, char *oldval, size_t *oldlen, char *newval, size_t *newlen);
+extern int (*sysctl)(int *name, unsigned int namelen, char *oldval, size_t *oldlen, char *newval, size_t newlen);
+extern int (*sysctlbyname)(char *name, char *oldval, size_t *oldlen, char *newval, size_t newlen);
 extern int (*sysarch)(int type, void *arg);
 extern int (*execve)(char *path, char *argv[], char *envp[]);
 int ioctl(int fd, unsigned long com, void *data);

--- a/libPS4/source/kernel.c
+++ b/libPS4/source/kernel.c
@@ -16,8 +16,8 @@ int (*sceKernelGettimeofday)(SceKernelTimeval *tp);
 uint64_t (*sceKernelGetProcessTime)(void);
 int (*sceKernelGetCurrentCpu)(void);
 
-int (*sysctl)(int *name, unsigned int namelen, char *oldval, size_t *oldlen, char *newval, size_t *newlen);
-int (*sysctlbyname)(char *name, char *oldval, size_t *oldlen, char *newval, size_t *newlen);
+int (*sysctl)(int *name, unsigned int namelen, char *oldval, size_t *oldlen, char *newval, size_t newlen);
+int (*sysctlbyname)(char *name, char *oldval, size_t *oldlen, char *newval, size_t newlen);
 int (*sysarch)(int type, void *arg);
 int (*execve)(char *path, char *argv[], char *envp[]);
 


### PR DESCRIPTION
`newlen` for `sysctl` and `sysctlbyname` should be `size_t`, not `size_t*`, per the FreeBSD docs: https://www.freebsd.org/cgi/man.cgi?sysctl(3)
